### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,6 +7,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/simonwoerpel/runpandarun/security/code-scanning/4](https://github.com/simonwoerpel/runpandarun/security/code-scanning/4)

Add an explicit `permissions` block in `.github/workflows/python.yml` at the workflow root so it applies to both jobs (`test` and `finish`) unless overridden.  
Best minimal safe fix without changing functionality: set `contents: read`, which is sufficient for checkout and typical CI read operations. If later needed, job-specific extra permissions can be added narrowly, but we should start with least privilege.

Edit region: directly under `on:` triggers (after line 8/9) and before `jobs:`.

No imports, methods, or definitions are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
